### PR TITLE
pin setuptools to prevent Markupsafe install problems

### DIFF
--- a/address_resolver/Dockerfile
+++ b/address_resolver/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV HOME /root
 ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /usr/src/
-RUN git clone https://github.com/elastic/spring-petclinic.git
+RUN git clone https://github.com/emanuil-tolev/spring-petclinic.git
 WORKDIR /usr/src/spring-petclinic/address_resolver/src
 RUN pip install gunicorn json-logging-py
 RUN pip install setuptools==45

--- a/address_resolver/Dockerfile
+++ b/address_resolver/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /usr/src/
 RUN git clone https://github.com/elastic/spring-petclinic.git
 WORKDIR /usr/src/spring-petclinic/address_resolver/src
 RUN pip install gunicorn json-logging-py
+RUN pip install setuptools==45
 RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 5000

--- a/docker/address-finder/Dockerfile
+++ b/docker/address-finder/Dockerfile
@@ -5,9 +5,10 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV HOME /root
 ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /usr/src/
-RUN git clone https://github.com/elastic/spring-petclinic.git
+RUN git clone https://github.com/emanuil-tolev/spring-petclinic.git
 WORKDIR /usr/src/spring-petclinic/address_resolver/src
 RUN pip install gunicorn json-logging-py
+RUN pip install setuptools==45
 RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 5000


### PR DESCRIPTION
Right now if I try `docker-compose up` on this repo, the `spring-address-finder` service gets into trouble as follows:

```
Step 8/12 : WORKDIR /usr/src/spring-petclinic/address_resolver/src
 ---> Running in 405d89f9a68e
Removing intermediate container 405d89f9a68e
 ---> 59fcf817800f
Step 9/12 : RUN pip install gunicorn json-logging-py
 ---> Running in 085be0bb2c76
[...]
Removing intermediate container 085be0bb2c76
 ---> f58cea9f9e80
Step 10/12 : RUN pip install --no-cache-dir -r requirements.txt
Collecting MarkupSafe==1.0
  Downloading MarkupSafe-1.0.tar.gz (14 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-8m4n0ufm/MarkupSafe/setup.py'"'"'; __file__='"'"'/tmp/pip-install-8m4n0ufm/MarkupSafe/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-qbl3ww3y
         cwd: /tmp/pip-install-8m4n0ufm/MarkupSafe/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-8m4n0ufm/MarkupSafe/setup.py", line 6, in <module>
        from setuptools import setup, Extension, Feature
    ImportError: cannot import name 'Feature'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Service 'spring-address-finder' failed to build: The command '/bin/sh -c pip install --no-cache-dir -r requirements.txt' returned a non-zero code: 1
```

I noted a fix [here](https://github.com/pypa/setuptools/issues/2017#issuecomment-605354361).

This is what fixed it for me locally, I can now run the service. It's very unusual to pin setuptools, but I'm not sure what else can fix it. Perhaps upgrading the MarkupSafe to a newer version which doesn't use deprecated setuptools functionality, but I can't look into that atm :).